### PR TITLE
Issue 36

### DIFF
--- a/test/alea-prose-tex.sh
+++ b/test/alea-prose-tex.sh
@@ -12,9 +12,9 @@ EDITION=$(realpath ~/Projekte/edition-ibn-nubatah)
 
 STYLESHEET=$SEED_DIR/xsl/projects/alea/latex/prose.xsl
 
-PARAMS="wit-catalog=$EDITION/WitnessCatalogue.xml {http://scdh.wwu.de/transform/edmac#}pstart-opt=\noindent"
+PARAMS="wit-catalog=$EDITION/WitnessCatalogue.xml {http://scdh.wwu.de/transform/edmac#}pstart-opt=\noindent debug-latex=true"
 
-FONTPARAMS="font=ArabicTypesetting fontsize=15pt fontscale=1.4"
+FONTPARAMS="font=ArabicTypesetting fontsize=15pt fontscale=1.4 fontfeatures=,AutoFakeBold=2.5"
 
 XSLT_CMD=$SEED_DIR/target/bin/xslt.sh
 

--- a/xsl/latex/libreledmac.xsl
+++ b/xsl/latex/libreledmac.xsl
@@ -87,7 +87,7 @@
                     be it in section headings, we have to use \setRL.
                     See issue #37. See also issue #36.
                 -->
-                <xsl:text>\setRL</xsl:text>
+                <!--xsl:text>\setRL</xsl:text-->
             </xsl:when>
         </xsl:choose>
     </xsl:function>

--- a/xsl/projects/alea/latex/prose.xsl
+++ b/xsl/projects/alea/latex/prose.xsl
@@ -47,6 +47,9 @@ target/bin/xslt.sh -config:saxon.he.xml -xsl:xsl/projects/alea/latex/prose.xsl -
   <!-- scaling factor of the main font -->
   <xsl:param name="fontscale" as="xs:string" select="'1'" required="false"/>
 
+  <!-- additional font features, must start with a comma, e.g. ,AutoFakeBold=3.5 -->
+  <xsl:param name="fontfeatures" as="xs:string" select="''"/>
+
   <!-- width of the verses' caesura in times of the tatweel (tatwir) elongation character -->
   <xsl:param name="tatweel-times" as="xs:integer" select="8" required="false"/>
 
@@ -433,6 +436,7 @@ target/bin/xslt.sh -config:saxon.he.xml -xsl:xsl/projects/alea/latex/prose.xsl -
       <xsl:value-of select="."/>
       <xsl:text>}[Scale=</xsl:text>
       <xsl:value-of select="$fontscale"/>
+      <xsl:value-of select="$fontfeatures"/>
       <xsl:text>]{</xsl:text>
       <xsl:value-of select="$font"/>
       <xsl:text>}</xsl:text>

--- a/xsl/projects/alea/latex/prose.xsl
+++ b/xsl/projects/alea/latex/prose.xsl
@@ -232,6 +232,8 @@ target/bin/xslt.sh -config:saxon.he.xml -xsl:xsl/projects/alea/latex/prose.xsl -
     package-version="1.0.0">
     <xsl:override>
 
+      <xsl:param name="edmac:section-workaround" as="xs:boolean" select="true()"/>
+
       <!-- make apparatus footnotes -->
       <xsl:template name="text:inline-footnotes">
         <xsl:context-item as="element()" use="required"/>
@@ -435,9 +437,10 @@ target/bin/xslt.sh -config:saxon.he.xml -xsl:xsl/projects/alea/latex/prose.xsl -
       <xsl:value-of select="$font"/>
       <xsl:text>}</xsl:text>
     </xsl:for-each>
+    <xsl:text>&lb;\setRTLmain</xsl:text>
 
-    <xsl:text>&lb;\newcommand*{\arabicobracket}{[}</xsl:text>
-    <xsl:text>&lb;\newcommand*{\arabiccbracket}{]}</xsl:text>
+    <xsl:text>&lb;\newcommand*{\arabicobracket}{]}</xsl:text>
+    <xsl:text>&lb;\newcommand*{\arabiccbracket}{[}</xsl:text>
     <xsl:text>&lb;\newcommand*{\arabicoparen}{)}</xsl:text>
     <xsl:text>&lb;\newcommand*{\arabiccparen}{(}</xsl:text>
     <xsl:text>&lb;\newcommand*{\arabicornateoparen}{﴿}</xsl:text>
@@ -453,6 +456,10 @@ target/bin/xslt.sh -config:saxon.he.xml -xsl:xsl/projects/alea/latex/prose.xsl -
     <xsl:text>&lb;\usepackage[perpage,para]{manyfoot}</xsl:text>
     -->
     <xsl:text>&lb;\usepackage{reledmac}</xsl:text>
+    <xsl:if test="$debug-latex">
+      <xsl:text>&lb;\firstlinenum{1}</xsl:text>
+      <xsl:text>&lb;\linenumincrement{1}</xsl:text>
+    </xsl:if>
     <xsl:text>&lb;\renewcommand{\footfudgefiddle}{100}</xsl:text>
     <xsl:text>&lb;\lineation{page}</xsl:text>
     <xsl:text>&lb;\linenummargin{outer}</xsl:text>
@@ -461,6 +468,7 @@ target/bin/xslt.sh -config:saxon.he.xml -xsl:xsl/projects/alea/latex/prose.xsl -
     <xsl:text>&lb;\Xnonbreakableafternumber</xsl:text>
     <xsl:text>&lb;\Xnumberonlyfirstinline</xsl:text>
     <xsl:text>&lb;\Xsymlinenum{ | }</xsl:text>
+    <xsl:text>&lb;\Xlemmafont{\normalfont}</xsl:text>
     <!--xsl:text>&lb;\Xwraplemma{\RL}</xsl:text>
     <xsl:text>&lb;\Xwrapcontent{\RL}</xsl:text-->
     <xsl:text>&lb;\setlength{\parindent}{0pt}</xsl:text>
@@ -527,7 +535,13 @@ target/bin/xslt.sh -config:saxon.he.xml -xsl:xsl/projects/alea/latex/prose.xsl -
       </xsl:otherwise>
     </xsl:choose>
 
-    <!--xsl:call-template name="text:latex-header-workaround36"/-->
+    <!-- workaround for broken sectioning commands in reledmac -->
+    <xsl:call-template name="text:latex-header-workaround36"/>
+    <xsl:text>&lb;\renewcommand*{\seedchapterfont}[1]{\bfseries #1}</xsl:text>
+    <xsl:text>&lb;\renewcommand*{\seedsectionfont}[1]{\bfseries #1}</xsl:text>
+    <xsl:text>&lb;\renewcommand*{\seedsubsectionfont}[1]{\bfseries #1}</xsl:text>
+    <xsl:text>&lb;\renewcommand*{\seedsubsubsectionfont}[1]{\bfseries #1}</xsl:text>
+
 
     <xsl:text>&lb;\setlength{\emergencystretch}{3em}</xsl:text>
   </xsl:template>

--- a/xsl/projects/alea/latex/prose.xsl
+++ b/xsl/projects/alea/latex/prose.xsl
@@ -363,6 +363,7 @@ target/bin/xslt.sh -config:saxon.he.xml -xsl:xsl/projects/alea/latex/prose.xsl -
     <xsl:text>&lb;\setlength{\lineskiplimit}{-100pt}</xsl:text>
 
     <xsl:call-template name="latex-front"/>
+    <xsl:text>&lb;&lb;\selectlanguage{arabic}</xsl:text>
     <xsl:text>&lb;&lb;%% main content</xsl:text>
     <xsl:apply-templates mode="text:text" select="/TEI/text/body"/>
     <xsl:text>&lb;</xsl:text>
@@ -434,10 +435,9 @@ target/bin/xslt.sh -config:saxon.he.xml -xsl:xsl/projects/alea/latex/prose.xsl -
       <xsl:value-of select="$font"/>
       <xsl:text>}</xsl:text>
     </xsl:for-each>
-    <xsl:text>&lb;\setRTLmain</xsl:text>
 
-    <xsl:text>&lb;\newcommand*{\arabicobracket}{]}</xsl:text>
-    <xsl:text>&lb;\newcommand*{\arabiccbracket}{[}</xsl:text>
+    <xsl:text>&lb;\newcommand*{\arabicobracket}{[}</xsl:text>
+    <xsl:text>&lb;\newcommand*{\arabiccbracket}{]}</xsl:text>
     <xsl:text>&lb;\newcommand*{\arabicoparen}{)}</xsl:text>
     <xsl:text>&lb;\newcommand*{\arabiccparen}{(}</xsl:text>
     <xsl:text>&lb;\newcommand*{\arabicornateoparen}{﴿}</xsl:text>
@@ -461,10 +461,11 @@ target/bin/xslt.sh -config:saxon.he.xml -xsl:xsl/projects/alea/latex/prose.xsl -
     <xsl:text>&lb;\Xnonbreakableafternumber</xsl:text>
     <xsl:text>&lb;\Xnumberonlyfirstinline</xsl:text>
     <xsl:text>&lb;\Xsymlinenum{ | }</xsl:text>
-    <xsl:text>&lb;\Xwraplemma{\RL}</xsl:text>
-    <xsl:text>&lb;\Xwrapcontent{\RL}</xsl:text>
-    <xsl:text>&lb;\AtEveryPstart{\noindent\setRL}</xsl:text>
+    <!--xsl:text>&lb;\Xwraplemma{\RL}</xsl:text>
+    <xsl:text>&lb;\Xwrapcontent{\RL}</xsl:text-->
     <xsl:text>&lb;\setlength{\parindent}{0pt}</xsl:text>
+    <xsl:text>&lb;%% setting for rtl</xsl:text>
+    <xsl:text>&lb;\Xbhookgroup{\textdir TRT}</xsl:text>
 
     <xsl:text>&lb;\pagestyle{plain}</xsl:text>
     <xsl:text>&lb;\setcounter{secnumdepth}{0}</xsl:text>
@@ -526,7 +527,7 @@ target/bin/xslt.sh -config:saxon.he.xml -xsl:xsl/projects/alea/latex/prose.xsl -
       </xsl:otherwise>
     </xsl:choose>
 
-    <xsl:call-template name="text:latex-header-workaround36"/>
+    <!--xsl:call-template name="text:latex-header-workaround36"/-->
 
     <xsl:text>&lb;\setlength{\emergencystretch}{3em}</xsl:text>
   </xsl:template>


### PR DESCRIPTION
This branch fixes #36 by adding a workaround for issues with reledmac's sectioning commands `\eledxxxx` as filed in maieul/ledmac#976 and maieul/ledmac#977.

The workaround rewrites these section commands like so:

```
\newcommand*{\seedsectionfont}[1]{\Large #1}
\renewcommand{\eledsection}[2][]{%
  \seedsectionfont{#2}%
  \ifthenelse{\equal{#1}{}}{%
    \addcontentsline{toc}{section}{#2}}{%
    \addcontentsline{toc}{section}{#1}}%
}
```

The redefinition does not contain vertical spacing, because using this inside `\pstart...\pend` results in similar issues. Instead, we add vertical spacing outside line numbering using XSLT hooks in `xsl/latex/libtext.xsl`.