### PR TITLE
Added table of contents

### DIFF
--- a/xsl/html/documentation.css
+++ b/xsl/html/documentation.css
@@ -96,3 +96,28 @@ section.transformation h6,
 section.transformation h7 {
     border-bottom: none;
 }
+.toc {
+    background-color: #f9f9f9;
+    border: 1px solid #ccc;
+    padding: 1em;
+    margin-bottom: 2em;
+    border-radius: 0.5em;
+}
+.toc ul {
+    list-style-type: none;
+    padding-left: 1.5em;
+}
+.toc > ul {
+    padding-left: 0;
+}
+.toc li {
+    margin: 0.2em 0;
+}
+.toc a {
+    text-decoration: none;
+    color: #333;
+}
+.toc a:hover {
+    text-decoration: underline;
+    color: #444;
+}

--- a/xsl/html/libodd.xsl
+++ b/xsl/html/libodd.xsl
@@ -67,6 +67,9 @@ target/bin/xslt.sh -config:saxon.he.xml -xsl:xsl/html/libodd.xsl -it:importing-a
     <!-- whether to use the HTML template from libhtml and make a full HTML file -->
     <xsl:param name="odd:transform" as="xs:boolean" select="true()"/>
 
+    <!-- whether to generate a TOC -->
+    <xsl:param name="odd:toc" as="xs:boolean" select="true()"/>
+
     <!-- path to directory containing documentation ODDs, only required for template named 'importing-ant-build-file' -->
     <xsl:param name="odd-dir" as="xs:string" select="''"/>
 
@@ -110,6 +113,9 @@ target/bin/xslt.sh -config:saxon.he.xml -xsl:xsl/html/libodd.xsl -it:importing-a
         <xsl:override>
 
             <xsl:template name="html:content">
+                <xsl:if test="$odd:toc">
+                    <xsl:call-template name="odd:toc"/>
+                </xsl:if>
                 <xsl:apply-templates mode="text:text"/>
             </xsl:template>
 
@@ -303,6 +309,36 @@ target/bin/xslt.sh -config:saxon.he.xml -xsl:xsl/html/libodd.xsl -it:importing-a
                 </tr>
             </xsl:when>
         </xsl:choose>
+    </xsl:template>
+
+
+
+    <!-- mode for generating a recursive TOC -->
+    <xsl:template name="odd:toc">
+        <nav class="toc">
+            <ul>
+                <xsl:apply-templates mode="odd:toc" select="//body/div"/>
+            </ul>
+        </nav>
+    </xsl:template>
+
+    <xsl:mode name="odd:toc" on-no-match="shallow-skip" visibility="public"/>
+
+    <xsl:template mode="odd:toc" match="div[head]">
+        <li>
+            <a href="#{if (@xml:id) then @xml:id else generate-id()}">
+                <xsl:apply-templates mode="odd:toc" select="head"/>
+            </a>
+            <xsl:if test="div[head]">
+                <ul>
+                    <xsl:apply-templates mode="odd:toc" select="div"/>
+                </ul>
+            </xsl:if>
+        </li>
+    </xsl:template>
+
+    <xsl:template mode="odd:toc" match="head">
+        <xsl:apply-templates mode="text:text"/>
     </xsl:template>
 
 


### PR DESCRIPTION
I have implemented a Table of Contents (TOC) for the documentation generated by 
libodd.xsl. Below is a summary of the changes:

1. XSLT Enhancements in libodd.xsl
New Parameter: Added odd:toc (boolean, defaults to true) to toggle the TOC.
TOC Logic: Created a dedicated odd:toc template and mode that recursively scans for tei:div elements containing a tei:head.
Anchor Integration: Links in the TOC use the same anchor logic as the main content (targeting the section's xml:id or a generated ID), ensuring seamless navigation.
Unified Layout: Integrated the TOC into the html:content template so it automatically appears at the top of the generated documentation.

2. Modern Styling in documentation.css
Layout: Added a stylized .toc container with a light background and subtle borders to differentiate it from the main content.
Hierarchy: Styled nested lists to clearly represent the document structure.
Interactivity: Added hover effects to TOC links for better user experience.

Closes issue #77  